### PR TITLE
Add patches for some broken packages

### DIFF
--- a/benchmark/monorepo-bench.opam.locked
+++ b/benchmark/monorepo-bench.opam.locked
@@ -4696,7 +4696,7 @@ pin-depends: [
   ]
   [
     "base32.1.0.0"
-    "https://inqlab.net/projects/ocaml-base32/release/ocaml-base32-v1.0.0.tar.gz"
+    "https://github.com/gridbugs/opam-source-archives/raw/base32.1.0.0/base32-1.0.0.tar.gz"
   ]
   [
     "base64.3.5.1"
@@ -5108,7 +5108,7 @@ pin-depends: [
   ["cbor.0.5" "https://ygrek.org/p/release/ocaml-cbor/ocaml-cbor-0.5.tar.gz"]
   [
     "cborl.0.1.0"
-    "https://inqlab.net/projects/ocaml-cborl/release/ocaml-cborl-v0.1.0.tar.gz"
+    "https://github.com/gridbugs/opam-source-archives/raw/cborl.0.1.0/cborl-0.1.0.tar.gz"
   ]
   [
     "ccbg.0.1"
@@ -7858,7 +7858,7 @@ pin-depends: [
   ]
   [
     "monocypher.0.1.0"
-    "https://inqlab.net/projects/ocaml-monocypher/release/ocaml-monocypher-v0.1.0.tar.gz"
+    "https://github.com/gridbugs/opam-source-archives/raw/monocypher.0.1.0/monocypher-0.1.0.tar.gz"
   ]
   [
     "monomorphic.2.1.0"
@@ -7898,7 +7898,7 @@ pin-depends: [
   ]
   [
     "mugen.0.1.0"
-    "https://github.com/RedPRL/mugen/archive/refs/tags/0.1.0.tar.gz"
+    "https://github.com/gridbugs/opam-source-archives/raw/mugen.0.1.0/mugen-0.1.0.tar.gz"
   ]
   [
     "mula.0.1.2"
@@ -11903,7 +11903,7 @@ x-opam-monorepo-duniverse-dirs: [
     ]
   ]
   [
-    "https://github.com/RedPRL/mugen/archive/refs/tags/0.1.0.tar.gz"
+    "https://github.com/gridbugs/opam-source-archives/raw/mugen.0.1.0/mugen-0.1.0.tar.gz"
     "mugen"
     [
       "md5=18d13a806906d47b31bd586f956c1b7e"
@@ -19161,7 +19161,7 @@ x-opam-monorepo-duniverse-dirs: [
     ]
   ]
   [
-    "https://inqlab.net/projects/ocaml-base32/release/ocaml-base32-v1.0.0.tar.gz"
+    "https://github.com/gridbugs/opam-source-archives/raw/base32.1.0.0/base32-1.0.0.tar.gz"
     "ocaml-base32"
     [
       "md5=04f0113150261bae2075381c18c6e60c"
@@ -19169,7 +19169,7 @@ x-opam-monorepo-duniverse-dirs: [
     ]
   ]
   [
-    "https://inqlab.net/projects/ocaml-cborl/release/ocaml-cborl-v0.1.0.tar.gz"
+    "https://github.com/gridbugs/opam-source-archives/raw/cborl.0.1.0/cborl-0.1.0.tar.gz"
     "ocaml-cborl"
     [
       "md5=855106fd1a3bed94af232eb168a51fd0"
@@ -19177,7 +19177,7 @@ x-opam-monorepo-duniverse-dirs: [
     ]
   ]
   [
-    "https://inqlab.net/projects/ocaml-monocypher/release/ocaml-monocypher-v0.1.0.tar.gz"
+    "https://github.com/gridbugs/opam-source-archives/raw/monocypher.0.1.0/monocypher-0.1.0.tar.gz"
     "ocaml-monocypher"
     [
       "md5=7d1350d7df38e2420f1fbd1567e553d8"

--- a/benchmark/patches/codept.diff
+++ b/benchmark/patches/codept.diff
@@ -1,0 +1,15 @@
+Fixes a syntax error in dune-project.
+
+diff --git a/dune-project b/dune-project
+index d014d06..f8bf85f 100644
+--- a/dune-project
++++ b/dune-project
+@@ -15,7 +15,7 @@
+   (version 0.11.0)
+   (license GPL-3.0-or-later)
+   (synopsis "Alternative ocaml dependency analyzer")
+-  (depends dune menhir {build & >= 20180523})
++  (depends dune menhir (and :build (>= 20180523)))
+   (description "Codept intends to be a dependency solver for OCaml project and an alternative to ocamldep. Compared to ocamldep, codept major features are:
+ 
+  * whole project analysis

--- a/benchmark/patches/ocaml-baguettesharp-interpreter.diff
+++ b/benchmark/patches/ocaml-baguettesharp-interpreter.diff
@@ -1,0 +1,14 @@
+Fixes a syntax error in dune-project.
+
+diff --git a/dune-project b/dune-project
+index 343791e..27042ae 100644
+--- a/dune-project
++++ b/dune-project
+@@ -19,6 +19,5 @@
+  (homepage https://baguettesharp.fr)
+  (synopsis "The Baguette# Interpreter REPL")
+  (description "The REPL for Baguette#")
+- (depends
+- {"ocaml">=4.13.1})
++ (depends (ocaml (>= 4.13.1)))
+  )


### PR DESCRIPTION
The packages `codept` and `baguette_sharp` contained syntax errors in their dune-project files. The error only started causing build failures in a recent version of dune. These fixes will be upstreamed but in the meantime we'll fix them with patches.

Also note that the "fixed" urls for missing packages refer to the files in my fork of opam-source-arcihves. I have PRs to add those packages upstream. I'll update the URLs when my PRs are merged.